### PR TITLE
Optimized build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
         with:
           submodules: recursive
 
-      # - name: Checking Formatting
-      #   run: |
-      #     clang-format --dry-run --Werror --ferror-limit=15 src/* include/* assets/shaders/*
+      - name: Checking Formatting
+        run: |
+          clang-format --dry-run --Werror --ferror-limit=15 src/* include/* assets/shaders/*
 
       - name: Building Project
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           cmake --build build
+          mv build/Debug/Indigo.exe build/
 
       - name: Uploading Binary
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         compiler: [{ cc: gcc, cxx: g++ }, { cc: clang, cxx: clang++ }]
@@ -24,7 +24,7 @@ jobs:
             output: build/Indigo.exe
 
     steps:
-      - if: ${{ matrix.os }} == 'ubuntu-latest'
+      - if: matrix.os == 'ubuntu-latest'
         name: Installing Dependencies
         run: |
           sudo apt-get update
@@ -40,7 +40,7 @@ jobs:
       #     clang-format --dry-run --Werror --ferror-limit=15 src/* include/* assets/shaders/*
 
       - name: Building Project
-        if: ${{ matrix.os }} == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest'
         env:
           CC: ${{ matrix.compiler.cc }}
           CXX: ${{ matrix.compiler.cxx }}
@@ -49,7 +49,7 @@ jobs:
           cmake --build build
 
       - name: Building Project
-        if: ${{ matrix.os }} == 'windows-latest'
+        if: matrix.os == 'windows-latest'
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           cmake --build build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Checking Formatting
-        run: |
-          clang-format --dry-run --Werror --ferror-limit=15 src/* include/* assets/shaders/*
+      # - name: Checking Formatting
+      #   run: |
+      #     clang-format --dry-run --Werror --ferror-limit=15 src/* include/* assets/shaders/*
 
       - name: Building Project
         if: ${{ matrix.os }} == 'ubuntu-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 jobs:
-  linux:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
@@ -17,12 +17,11 @@ jobs:
         build_type: [Release]
         binary: [linux-binary]
         output: [build/Indigo]
-
         include:
           - os: windows-latest
-          - build_type: Release
-          - binary: windows-binary
-          - output: build/Indigo.exe
+            build_type: Release
+            binary: windows-binary
+            output: build/Indigo.exe
 
     steps:
       - if: ${{ matrix.os }} == 'ubuntu-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Checking Formatting
+        run: |
+          clang-format --dry-run --Werror --ferror-limit=15 src/* include/* assets/shaders/*
+
       - name: Building Project
         env:
           CC: ${{ matrix.compiler.cc }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Checking Formatting
+      # Only run checks on Linux because Windows command line is trash
+      - if: matrix.os == 'ubuntu-latest'
+        name: Checking Formatting
         run: |
           clang-format --dry-run --Werror --ferror-limit=15 src/* include/* assets/shaders/*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,23 @@ jobs:
   linux:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest]
         compiler: [{ cc: gcc, cxx: g++ }, { cc: clang, cxx: clang++ }]
         build_type: [Release]
+        binary: [linux-binary]
+        output: [build/Indigo]
+
+        include:
+          - os: windows-latest
+          - build_type: Release
+          - binary: windows-binary
+          - output: build/Indigo.exe
 
     steps:
-      - name: Installing Dependencies
+      - if: ${{ matrix.os }} == 'ubuntu-latest'
+        name: Installing Dependencies
         run: |
           sudo apt-get update
           sudo apt-get -y install ${{ matrix.compiler.cc }} cmake ninja-build libglu1-mesa-dev mesa-common-dev xorg-dev
@@ -32,6 +41,7 @@ jobs:
           clang-format --dry-run --Werror --ferror-limit=15 src/* include/* assets/shaders/*
 
       - name: Building Project
+        if: ${{ matrix.os }} == 'ubuntu-latest'
         env:
           CC: ${{ matrix.compiler.cc }}
           CXX: ${{ matrix.compiler.cxx }}
@@ -39,37 +49,14 @@ jobs:
           cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           cmake --build build
 
-      - name: Uploading Binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: linux-binary
-          path: build/Indigo
-
-  windows:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest]
-        compiler: [{ cc: clang, cxx: clang++ }]
-        build_type: [Release]
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
       - name: Building Project
-        env:
-          CC: ${{ matrix.compiler.cc }}
-          CXX: ${{ matrix.compiler.cxx }}
+        if: ${{ matrix.os }} == 'windows-latest'
         run: |
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           cmake --build build
 
       - name: Uploading Binary
         uses: actions/upload-artifact@v3
         with:
-          name: windows-binary
-          path: build/Indigo.exe
+          name: ${{ matrix.binary }}
+          path: ${{ matrix.output }}


### PR DESCRIPTION
Reduced duplicate config in build.yml
Windows builds now use CMake + MSVC
Added config for running `clang-format` checking ~~but due to concerns of merge conflicts it's turned off for now~~
No changes are made to release.yml